### PR TITLE
Robust stamp duty calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## 3.1.1 - 2026-05-28
+### Fixed
+- Stamp duty calculation is now evaluated per bracket independently, so a typo, gap, or overlap in the rates table (e.g. min greater than max) no longer silently skips later brackets or cascades into incorrect totals.
+- Display breakdown is now sorted ascending by bracket minimum regardless of source data ordering.
+
 ## 3.0.0 - 2025-03-19
 ### Release
 - Craft 5 Compatibility

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "burnthebook/craft-mortgage-calculator",
     "description": "Craft CMS Plugin to calculate UK mortgage costs",
     "type": "craft-plugin",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "keywords": [
         "craft",
         "cms",

--- a/src/templates/js.js
+++ b/src/templates/js.js
@@ -2,47 +2,32 @@
 
     function getStampDuty(price) {
 
-        let origPrice = price;
         let location = 'ENG';
-        let property = 'first';
-
+        let column = 'first';
         let first = $('#firstTimeBuyer').val() === 'yes' ? '1' : '0';
 
-//no stamp duty to pay ...yet
         let payable = 0;
-        let difference = 0;
 
         $.each(rates, function (i) {
+            let r = rates[i];
+            if (r['location'] != location || r['property'] != first) return;
 
+            let bracketMin = parseFloat(r['bracketMin']);
+            let bracketMax = parseFloat(r['bracketMax']);
+            let rate = parseFloat(r[column]);
 
-            if (rates[i]['location'] == location && rates[i]['property'] == first) {
+            if (isNaN(bracketMin)) bracketMin = 0;
+            if (isNaN(bracketMax)) bracketMax = Infinity;
+            if (isNaN(rate)) return;
 
-// at this point we only have rates that match the location
+            // Defensive: skip nonsensical brackets where min >= max (e.g. data entry typo).
+            if (bracketMin >= bracketMax) return;
 
-                bracketMin = parseInt(rates[i]['bracketMin']);
-                bracketMax = parseInt(rates[i]['bracketMax']);
+            let portionEnd = Math.min(price, bracketMax);
+            if (portionEnd <= bracketMin) return;
 
-                if (isNaN(bracketMax)) {
-                    bracketMax = 'e';
-                }
-
-
-                if (origPrice > bracketMin) {
-
-
-                    if (bracketMax === 'e' || origPrice <= bracketMax) {
-                        bracketMax = bracketMin + price;
-                    }
-
-                    difference = bracketMax - bracketMin;
-
-                    payable += (difference / 100) * rates[i][property];
-                    price = price - difference;
-
-                }
-
-            }
-
+            let amountInBracket = portionEnd - bracketMin;
+            payable += (amountInBracket / 100) * rate;
         });
 
         return payable;
@@ -300,50 +285,52 @@
             first = 0;
         }
 
-//no stamp duty to pay ...yet
         let payable = 0;
-        let difference = 0;
         let totalCost = 0;
-        let payableInBracket = 0;
-
-        let html = '<div class="row">';
+        let breakdown = [];
 
         $.each(rates, function (i) {
-            if (rates[i]['location'] == location && rates[i]['property'] == first) {
-                // at this point we only have rates that match the location
+            let r = rates[i];
+            if (r['location'] != location || r['property'] != first) return;
 
-                bracketMin = parseInt(rates[i]['bracketMin']);
-                bracketMax = parseInt(rates[i]['bracketMax']);
+            let bracketMin = parseFloat(r['bracketMin']);
+            let bracketMax = parseFloat(r['bracketMax']);
+            let rate = parseFloat(r[property]);
 
-                if (isNaN(bracketMax)) {
-                    bracketMax = 'e';
-                }
+            if (isNaN(bracketMin)) bracketMin = 0;
+            if (isNaN(bracketMax)) bracketMax = Infinity;
+            if (isNaN(rate)) return;
 
-                if (origPrice > bracketMin) {
+            // Defensive: skip nonsensical brackets where min >= max (e.g. data entry typo).
+            if (bracketMin >= bracketMax) return;
 
-                    if (bracketMax === 'e' || origPrice <= bracketMax) {
-                        bracketMax = bracketMin + price;
-                    }
+            let portionEnd = Math.min(origPrice, bracketMax);
+            if (portionEnd <= bracketMin) return;
 
-                    difference = bracketMax - bracketMin;
+            let amountInBracket = portionEnd - bracketMin;
+            let payableInBracket = (amountInBracket / 100) * rate;
 
-                    payableInBracket = (difference / 100) * rates[i][property];
-
-                    html += '<div class="row calc-result__bracket">';
-                    html += '<p class="columns small-8 medium-9">You pay ' + rates[i][property] + '% up to £' + money(bracketMax) + '</p>';
-                    html += '<p class="columns small-4 medium-3 calc-result__bracket-right">£' + money(payableInBracket.toFixed(2)) + '</p>';
-                    html += '</div><!-- row -->';
-
-                    payable += (difference / 100) * rates[i][property];
-                    price = price - difference;
-
-                    totalCost = origPrice + payable;
-
-                }
-            }
+            payable += payableInBracket;
+            breakdown.push({
+                bracketMin: bracketMin,
+                upTo: portionEnd,
+                rate: rate,
+                payableInBracket: payableInBracket
+            });
         });
 
-        html += '';
+        // Sort breakdown ascending so display is always logical, even if source data is unordered.
+        breakdown.sort(function (a, b) { return a.bracketMin - b.bracketMin; });
+
+        let html = '<div class="row">';
+        breakdown.forEach(function (b) {
+            html += '<div class="row calc-result__bracket">';
+            html += '<p class="columns small-8 medium-9">You pay ' + b.rate + '% up to £' + money(b.upTo) + '</p>';
+            html += '<p class="columns small-4 medium-3 calc-result__bracket-right">£' + money(b.payableInBracket.toFixed(2)) + '</p>';
+            html += '</div><!-- row -->';
+        });
+
+        totalCost = origPrice + payable;
 
         $('#stampDutyPayable').html('£' + money(payable.toFixed(2)));
         $('#stampDutyBrackets').html(html);


### PR DESCRIPTION
## Summary
- Rewrites both stamp duty calculations (the affordability helper `getStampDuty` and the standalone form submit handler) so each bracket is evaluated independently against the price.
- Previously the loop walked a running balance through ordered brackets. If the rates table had a typo, gap, or overlap (e.g. a `bracketMin` greater than `bracketMax` from an extra zero), the running balance would be corrupted and later brackets silently skipped — producing wrong-but-plausible totals with no warning.
- Now each bracket contributes `(min(price, bracketMax) - bracketMin) × rate%` independently; nonsensical brackets where `min >= max` are skipped, and the price-breakdown display is sorted ascending defensively in JS so source data order can no longer affect what the user sees.

## Why
Real-world trigger: a single extra zero in the staging rates table (`9250000` instead of `925000`) caused the 10% England & NI band to vanish from results because its `min` exceeded its `max`, and the over-wide 5% band ate the running price before higher bands could apply. This change degrades gracefully against that class of data-entry mistake.

## Test plan
- [ ] On staging, correct the `9250000` → `925000` typo and confirm the calculator returns expected totals across a few price points (e.g. £500k, £1M, £2M).
- [ ] Confirm FTB toggle still behaves correctly (including the `> £625k` ENG cutoff).
- [ ] Confirm Scotland and Wales calculations are unchanged for valid data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)